### PR TITLE
nix: initial packaging & tooling

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,24 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
 
-  outputs = {nixpkgs, ...}: let
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
     systems = ["x86_64-linux" "aarch64-linux"];
     forEachSystem = nixpkgs.lib.genAttrs systems;
     pkgsForEach = nixpkgs.legacyPackages;
   in {
     packages = forEachSystem (system: {
-      default = pkgsForEach.${system}.callPackage ./nix/package.nix {};
+      microlauncher = pkgsForEach.${system}.callPackage ./nix/package.nix {};
+      default = self.packages.${system}.microlauncher;
     });
 
     devShells = forEachSystem (system: {
       default = pkgsForEach.${system}.callPackage ./nix/shell.nix {};
     });
+
+    hydraJobs = self.packages;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+
+  outputs = {nixpkgs, ...}: let
+    systems = ["x86_64-linux" "aarch64-linux"];
+    forEachSystem = nixpkgs.lib.genAttrs systems;
+    pkgsForEach = nixpkgs.legacyPackages;
+  in {
+    packages = forEachSystem (system: {
+      default = pkgsForEach.${system}.callPackage ./nix/package.nix {};
+    });
+
+    devShells = forEachSystem (system: {
+      default = pkgsForEach.${system}.callPackage ./nix/shell.nix {};
+    });
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  gtk4,
+  curl,
+  openssl,
+  libuuid,
+  json_c,
+  libzip,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "microlauncher";
+  version = "0.1";
+
+  src = builtins.path {
+    path = ../.;
+    name = finalAttrs.pname;
+  };
+
+
+  strictDeps = true;
+  nativeBuildInputs = [meson ninja pkg-config];
+  buildInputs = [
+    gtk4
+    curl
+    openssl
+    libuuid
+    json_c
+    libzip
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm766 microlauncher $out/bin/
+  '';
+})

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,6 +1,9 @@
 {
   mkShell,
   gdb,
+  meson,
+  ninja,
+  pkg-config,
   gtk4,
   curl,
   openssl,
@@ -11,7 +14,7 @@
 mkShell {
   name = "C";
 
-  packages = [gdb]
+  packages = [gdb];
 
   nativeBuildInputs = [meson ninja pkg-config];
   buildInputs = [

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,25 @@
+{
+  mkShell,
+  gdb,
+  gtk4,
+  curl,
+  openssl,
+  libuuid,
+  json_c,
+  libzip,
+}:
+mkShell {
+  name = "C";
+
+  packages = [gdb]
+
+  nativeBuildInputs = [meson ninja pkg-config];
+  buildInputs = [
+    gtk4
+    curl
+    openssl
+    libuuid
+    json_c
+    libzip
+  ];
+}


### PR DESCRIPTION
This MR initiates a baseline Nix toolchain so that we can

1. Build Microlauncher with Nix.
2. Build *without* Nix, using a dev shell introduced by Nix.

The version had to be hardcoded since I don't have an easy and pure way of inferring it from meson.build, but this can be solved by introducing a VERSION file (or a JSON manifest with project data) that can be shared with Nix and Meson.

I'll send a followup PR cleaning up the toolchain with futher QOL later today.