### PR TITLE
Add macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .vscode/
 .cache/
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.0.3)
+cmake_minimum_required(VERSION 3.31.0)
 project(microlauncher VERSION 1.0.0 LANGUAGES C CXX)
 
 set(MICROSOFT_CLIENT_ID "95984717-05f1-4b52-8a66-064d0e1e5b55" CACHE STRING "Azure application client ID used for microsoft authentication")
@@ -25,7 +25,7 @@ find_package(PkgConfig REQUIRED)
 set(DEPS
     gtk4 json-c gio-2.0 glib-2.0 gobject-2.0 libcurl libcrypto libzip
 )
-if(UNIX)
+if(UNIX AND NOT APPLE)
     list(APPEND DEPS uuid libpci)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 MicroLauncher is a Minecraft launcher implementation for official game client JSONs which are hosted by Mojang at https://launchermeta.mojang.com/mc/game/version_manifest_v2.json
 
 ## Features
-- Supports Windows and Linux
+- Supports Windows, Linux, and macOS.
 - By default MicroLauncher uses [BetterJSONs](https://github.com/MCPHackers/BetterJSONs) which bundle slightly different libraries for versions prior to 1.13 to provide better experience. `-lwjgl3` JSONs use [legacy-lwjgl3](https://github.com/MCPHackers/legacy-lwjgl3) to allow better Wayland support via glfw instead of using the broken LWJGL 2 implementation.
 
 ## Build dependencies
@@ -14,9 +14,19 @@ For building this project it is recommended to use CMake. Meson support is to be
 pacman -Sy gtk4 glib2 util-linux-libs json-c curl libzip openssl
 ```
 
-### MSYS2 with MinGW
+### Fedora Linux:
+```
+sudo dnf install gtk4 json-c libzip gtk4-devel json-c-devel libzip-devel pciutils pciutils-devel
+```
+
+### MSYS2 with MinGW:
 ```
 pacman -Sy mingw-w64-x86_64-gtk4 mingw-w64-x86_64-glib2 mingw-w64-x86_64-json-c mingw-w64-x86_64-curl-winssl mingw-w64-x86_64-libzip mingw-w64-x86_64-openssl
+```
+
+### macOS:
+```
+brew install gtk4 json-c libzip
 ```
 
 ## TODO

--- a/microlauncher.c
+++ b/microlauncher.c
@@ -22,6 +22,16 @@
 #include <unistd.h>
 #include <zip.h>
 
+#ifdef __linux__
+#include <linux/limits.h>
+#endif
+
+// macOS uses an outdated version of libcurl
+// which does not have this constant defined.
+#ifndef CURLFOLLOW_ALL
+#define CURLFOLLOW_ALL 1L
+#endif
+
 static GSList *instances;
 static GSList *accounts;
 

--- a/util.c
+++ b/util.c
@@ -3,8 +3,8 @@
 #ifdef __linux
 #include <linux/limits.h>
 #endif
-#ifdef __unix
-#include "uuid.h"
+#if defined(__unix) || defined(__APPLE__)
+#include <uuid/uuid.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #endif

--- a/xdgutil.c
+++ b/xdgutil.c
@@ -1,15 +1,21 @@
 #include "xdgutil.h"
-#include "glib.h"
-#ifdef __linux__
-#include "linux/limits.h"
+#include <glib.h>
+
+#if defined(__unix) || defined(__APPLE__)
 #include <pwd.h>
-#elif _WIN32
+#endif
+
+#ifdef __linux
+#include <linux/limits.h>
+#endif
+
+#if _WIN32
 #include <shlobj.h>
 #include <windows.h>
 #endif
-#include "stdbool.h"
-#include "stdio.h"
-#include "stdlib.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 


### PR DESCRIPTION
- Add macOS support
- Add Fedora Linux and macOS build instructions
- Use brackets for global/toolchain include paths instead of quotations

Additionally, this PR downgrades the cmake version required as it is unnecessarily new and may require building CMake from source on fixed release distributions.